### PR TITLE
Always init the board

### DIFF
--- a/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
+++ b/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
@@ -26,6 +26,10 @@ class ChessBoardView @JvmOverloads constructor(
 
     private lateinit var position: Position
 
+    init {
+        setFen("")
+    }
+    
     fun setFen(fen: String) {
         try {
             position = FenUtil.readFEN(fen)


### PR DESCRIPTION
This means you don't have to call "setFen", by default the view will show an empty board.