### PR TITLE
Measure and fix board width and height

### DIFF
--- a/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
+++ b/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
@@ -179,8 +179,6 @@ class ChessBoardView @JvmOverloads constructor(
     }
 
     private fun getDesiredDimensions(widthMeasureSpec: Int, heightMeasureSpec: Int): Pair<Int, Int> {
-        Log.v("ChessBoardView", "measured width ${MeasureSpec.toString(widthMeasureSpec)}")
-        Log.v("ChessBoardView", "measured height ${MeasureSpec.toString(heightMeasureSpec)}")
         val measuredWidth = MeasureSpec.getSize(widthMeasureSpec)
         val measuredHeight = MeasureSpec.getSize(heightMeasureSpec)
         val normalizedWidth = measuredWidth * BOARD_HEIGHT_RATIO
@@ -188,8 +186,6 @@ class ChessBoardView @JvmOverloads constructor(
         val minNormalized = min(normalizedWidth, normalizedHeight)
         val desiredWidth = minNormalized / BOARD_HEIGHT_RATIO
         val desiredHeight = minNormalized / BOARD_WIDTH_RATIO
-        Log.v("ChessBoardView", "desired width $desiredWidth")
-        Log.v("ChessBoardView", "desired height $desiredHeight")
         return desiredWidth to desiredHeight
     }
 

--- a/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
+++ b/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/board/ChessBoardView.kt
@@ -18,18 +18,24 @@ import no.bakkenbaeck.chessboardeditor.view.piece.ChessPieceView
 import no.bakkenbaeck.chessboardeditor.view.row.ChessInnerRowView
 import no.bakkenbaeck.chessboardeditor.view.row.ChessSideRowView
 import no.bakkenbaeck.chessboardeditor.view.row.ChessWhiteSpaceRowView
+import kotlin.math.min
 
 class ChessBoardView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : TableLayout(context, attrs) {
 
+    companion object {
+        const val BOARD_WIDTH_RATIO = 8
+        const val BOARD_HEIGHT_RATIO = 11
+    }
+
     private lateinit var position: Position
 
     init {
         setFen("")
     }
-    
+
     fun setFen(fen: String) {
         try {
             position = FenUtil.readFEN(fen)
@@ -163,5 +169,32 @@ class ChessBoardView @JvmOverloads constructor(
             pieceView.setPiece(piece)
             cell.setPiece(pieceView)
         }
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val (desiredWidth, desiredHeight) = getDesiredDimensions(widthMeasureSpec, heightMeasureSpec)
+        setMeasuredDimension(desiredWidth, desiredHeight)
+        setWidthHeight(desiredWidth, desiredHeight)
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+
+    private fun getDesiredDimensions(widthMeasureSpec: Int, heightMeasureSpec: Int): Pair<Int, Int> {
+        Log.v("ChessBoardView", "measured width ${MeasureSpec.toString(widthMeasureSpec)}")
+        Log.v("ChessBoardView", "measured height ${MeasureSpec.toString(heightMeasureSpec)}")
+        val measuredWidth = MeasureSpec.getSize(widthMeasureSpec)
+        val measuredHeight = MeasureSpec.getSize(heightMeasureSpec)
+        val normalizedWidth = measuredWidth * BOARD_HEIGHT_RATIO
+        val normalizedHeight = measuredHeight * BOARD_WIDTH_RATIO
+        val minNormalized = min(normalizedWidth, normalizedHeight)
+        val desiredWidth = minNormalized / BOARD_HEIGHT_RATIO
+        val desiredHeight = minNormalized / BOARD_WIDTH_RATIO
+        Log.v("ChessBoardView", "desired width $desiredWidth")
+        Log.v("ChessBoardView", "desired height $desiredHeight")
+        return desiredWidth to desiredHeight
+    }
+
+    private fun setWidthHeight(width: Int, height: Int) {
+        layoutParams.width = width
+        layoutParams.height = height
     }
 }


### PR DESCRIPTION
Used `onMeasure` to make sure the board dimensions get correctly measured (with a fixed 8:11 ratio) and therefore we can use dynamic width and height (`wrap_content`, `match_parent`, `0dp` ...)