### PR TITLE
Correct the chessboard orientation

### DIFF
--- a/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/cell/ChessInnerCellView.kt
+++ b/chessboardeditor/src/main/java/no/bakkenbaeck/chessboardeditor/view/cell/ChessInnerCellView.kt
@@ -15,5 +15,5 @@ class ChessInnerCellView @JvmOverloads constructor(
         else setBackgroundColor(ContextCompat.getColor(context, R.color.boardCellDark))
     }
 
-    private fun isLightCell(row: Int, col: Int) = (row + col) % 2 == 0
+    private fun isLightCell(row: Int, col: Int) = (row + col) % 2 != 0
 }


### PR DESCRIPTION
The simple way to remember how to orient the board is "white on the right".

In other words, H1 and A8 are both white squares, and they appear on the right side of the first row for both players when the board is correctly oriented.